### PR TITLE
adding errorOnDuplicate option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ You can also pass an object with configurable options:
 ```js
 new DuplicatePackageCheckerPlugin({
   // Also show module that is requiring each duplicate package
-   verbose: true
+  verbose: true,
+  // Have webpack exit with an error if duplicates are found
+  emitError: true
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You can also pass an object with configurable options:
 new DuplicatePackageCheckerPlugin({
   // Also show module that is requiring each duplicate package
   verbose: true,
-  // Have webpack exit with an error if duplicates are found
+  // Emit errors instead of warnings
   emitError: true
 })
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ var _ = require('lodash');
 
 const defaults = {
   verbose: false,
-  errorOnDuplicate: false
+  emitError: false
 };
 
 function DuplicatePackageCheckerPlugin(options) {
@@ -45,7 +45,7 @@ function getClosestPackage(modulePath) {
 
 DuplicatePackageCheckerPlugin.prototype.apply = function(compiler) {
   let verbose = this.options.verbose;
-  let errorOnDuplicate = this.options.errorOnDuplicate;
+  let emitError = this.options.emitError;
 
   compiler.plugin('emit', function(compilation, callback) {
 
@@ -123,7 +123,7 @@ DuplicatePackageCheckerPlugin.prototype.apply = function(compiler) {
         error += `    ${instances.join('\n    ')}\n`;
       });
 
-      let array = errorOnDuplicate ? compilation.errors : compilation.warnings;
+      let array = emitError ? compilation.errors : compilation.warnings;
       array.push(new Error(error));
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,8 @@ var chalk = require('chalk');
 var _ = require('lodash');
 
 const defaults = {
-  verbose: false
+  verbose: false,
+  errorOnDuplicate: false
 };
 
 function DuplicatePackageCheckerPlugin(options) {
@@ -44,6 +45,7 @@ function getClosestPackage(modulePath) {
 
 DuplicatePackageCheckerPlugin.prototype.apply = function(compiler) {
   let verbose = this.options.verbose;
+  let errorOnDuplicate = this.options.errorOnDuplicate;
 
   compiler.plugin('emit', function(compilation, callback) {
 
@@ -121,8 +123,8 @@ DuplicatePackageCheckerPlugin.prototype.apply = function(compiler) {
         error += `    ${instances.join('\n    ')}\n`;
       });
 
-      compilation.warnings.push(new Error(error));
-
+      let array = errorOnDuplicate ? compilation.errors : compilation.warnings;
+      array.push(new Error(error));
     }
 
     callback();

--- a/test/simple/index.test.js
+++ b/test/simple/index.test.js
@@ -25,7 +25,7 @@ describe('Simple dependency tree', function() {
   it('should output errors', function(done) {
     let error = "duplicate-package-checker:\n  <a>\n    1.0.0 ./~/a\n    2.0.0 ./~/b/~/a\n\n  <b>\n    1.0.0 ./~/b\n    2.0.0 ./~/c/~/d/~/b\n";
 
-    webpack(MakeConfig({ errorOnDuplicate: true }), function(err, stats) {
+    webpack(MakeConfig({ emitError: true }), function(err, stats) {
       assert.equal(stripAnsi(stats.compilation.errors[0].message), error);
       done();
     });

--- a/test/simple/index.test.js
+++ b/test/simple/index.test.js
@@ -21,4 +21,13 @@ describe('Simple dependency tree', function() {
       done();
     });
   });
+
+  it('should output errors', function(done) {
+    let error = "duplicate-package-checker:\n  <a>\n    1.0.0 ./~/a\n    2.0.0 ./~/b/~/a\n\n  <b>\n    1.0.0 ./~/b\n    2.0.0 ./~/c/~/d/~/b\n";
+
+    webpack(MakeConfig({ errorOnDuplicate: true }), function(err, stats) {
+      assert.equal(stripAnsi(stats.compilation.errors[0].message), error);
+      done();
+    });
+  });
 });


### PR DESCRIPTION
I'm POC-ing some stuff for a build setup and was looking for a way to have a build fail if duplicate packages were detected in the bundle. This plugin got me most of the way there. I just needed to add an option and push to `compilation.errors` instead of `compilation.warnings`. 

I still need to do some big picture thinking, but something like this helps in the short term.

Example output (with `verbose`):

```
[bcentra] app-one $ npm run build

> app-one@1.0.0 build /Users/bcentra/Projects/build-example/app-one
> webpack --config webpack.config.js

Hash: d6cd47e59cafaf4b15cc
Version: webpack 3.2.0
Time: 426ms
    Asset    Size  Chunks                    Chunk Names
bundle.js  536 kB       0  [emitted]  [big]  main
   [0] ./src/index.js 113 bytes {0} [built]
    + 5 hidden modules

ERROR in duplicate-package-checker:
  <jquery>
    3.0.0 ./~/library-one/~/jquery from ./~/library-one/~/component-one/src/index.js
    3.2.1 ./~/library-one/~/component-two/~/jquery from ./~/library-one/~/component-two/src/index.js

npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! app-one@1.0.0 build: `webpack --config webpack.config.js`
npm ERR! Exit status 2
npm ERR!
npm ERR! Failed at the app-one@1.0.0 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/bcentra/.npm/_logs/2017-07-12T21_35_54_958Z-debug.log
```