### PR TITLE
Add exclude option (#11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,21 @@ new DuplicatePackageCheckerPlugin({
   // Also show module that is requiring each duplicate package
   verbose: true,
   // Emit errors instead of warnings
-  emitError: true
+  emitError: true,
+  /**
+   * Exclude instances of packages from the results.
+   * If all instances of a package are excluded, or all instances except one,
+   * then the package is no longer considered duplicated and won't be emitted as a warning/error.
+   * @param {Object} instance
+   * @param {string} instance.name The name of the package
+   * @param {string} instance.version The version of the package
+   * @param {string} instance.path Absolute path to the package
+   * @param {?string} instance.issuer Absolute path to the module that requested the package
+   * @returns {boolean} true to exclude the instance, false otherwise
+   */
+  exclude(instance) {
+    return instance.name === 'fbjs';
+  }
 })
 ```
 

--- a/test/simple/index.test.js
+++ b/test/simple/index.test.js
@@ -30,4 +30,28 @@ describe('Simple dependency tree', function() {
       done();
     });
   });
+
+  it('should not output warnings for package "a"', function(done) {
+    let warning = "duplicate-package-checker:\n  <b>\n    1.0.0 ./~/b\n    2.0.0 ./~/c/~/d/~/b\n";
+
+    webpack(MakeConfig({
+      exclude: function (instance) {
+        return instance.name === 'a';
+      }
+    }), function(err, stats) {
+      assert.equal(stripAnsi(stats.compilation.warnings[0].message), warning);
+      done();
+    });
+  });
+
+  it('should not output warnings', function(done) {
+    webpack(MakeConfig({
+      exclude: function (instance) {
+        return instance.issuer === './entry.js';
+      }
+    }), function(err, stats) {
+      assert(stats.compilation.warnings.length === 0);
+      done();
+    });
+  });
 });

--- a/test/simple/index.test.js
+++ b/test/simple/index.test.js
@@ -31,7 +31,7 @@ describe('Simple dependency tree', function() {
     });
   });
 
-  it('should not output warnings for package "a"', function(done) {
+  it('should ignore excluded duplicates by name', function(done) {
     let warning = "duplicate-package-checker:\n  <b>\n    1.0.0 ./~/b\n    2.0.0 ./~/c/~/d/~/b\n";
 
     webpack(MakeConfig({
@@ -44,7 +44,7 @@ describe('Simple dependency tree', function() {
     });
   });
 
-  it('should not output warnings', function(done) {
+  it('should ignore excluded duplicates by issuer', function(done) {
     webpack(MakeConfig({
       exclude: function (instance) {
         return instance.issuer === './entry.js';


### PR DESCRIPTION
Fixes #11.

I made the function per instance instead of per package. Per package is more powerful because you can directly compare multiple instances of package with each other, but it results in a more complicated API and I couldn't think of an actual use case for it.