### PR TITLE
Add emitWarning option, false = only output to console.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ new DuplicatePackageCheckerPlugin({
   verbose: true,
   // Emit errors instead of warnings (default: false)
   emitError: true,
+  // If set to false, warnings & errors will not be emitted. The conflicting packages will be printed out to the console instead. (default: true)
+  emitWarning: true, 
   // Show help message if duplicate packages are found (default: true)
   showHelp: false,
   // Warn also if major versions differ (default: true)

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ const defaults = {
   verbose: false,
   showHelp: true,
   emitError: false,
+  emitWarning: true,
   exclude: null,
   strict: true
 };
@@ -51,6 +52,7 @@ DuplicatePackageCheckerPlugin.prototype.apply = function(compiler) {
   let verbose = this.options.verbose;
   let showHelp = this.options.showHelp;
   let emitError = this.options.emitError;
+  let emitWarning = this.options.emitWarning;
   let exclude = this.options.exclude;
   let strict = this.options.strict;
 
@@ -180,7 +182,11 @@ DuplicatePackageCheckerPlugin.prototype.apply = function(compiler) {
             "Check how you can resolve duplicate packages: "
           )}\nhttps://github.com/darrenscerri/duplicate-package-checker-webpack-plugin#resolving-duplicate-packages-in-your-bundle\n`;
         }
-        array.push(new Error(error));
+        if (emitWarning) {
+          array.push(new Error(error));
+        } else {
+          console.log(error);
+        }
       });
     }
 


### PR DESCRIPTION
This PR adds the ability to disable emitting warnings when a duplicate is found.

I made the change against the 2.1.0 version because I'm using Webpack 3. There doesn't seem to be a 2.x branch for me to open this PR against. 