### PR TITLE
Add support for using custom error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ new DuplicatePackageCheckerPlugin({
   emitError: true,
   // Show help message if duplicate packages are found (default: true)
   showHelp: false,
+  // A custom help message (default: null)
+  helpMessage: "Check http://foo.bar.com/baz for more details how to update pacakges",
   // Warn also if major versions differ (default: true)
   strict: false,
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,8 @@ const defaults = {
   showHelp: true,
   emitError: false,
   exclude: null,
-  strict: true
+  strict: true,
+  helpMessage: null
 };
 
 function DuplicatePackageCheckerPlugin(options) {
@@ -53,6 +54,7 @@ DuplicatePackageCheckerPlugin.prototype.apply = function(compiler) {
   let emitError = this.options.emitError;
   let exclude = this.options.exclude;
   let strict = this.options.strict;
+  let helpMessage = this.options.helpMessage;
 
   compiler.hooks.emit.tapAsync("DuplicatePackageCheckerPlugin", function(
     compilation,
@@ -186,9 +188,13 @@ DuplicatePackageCheckerPlugin.prototype.apply = function(compiler) {
         error += `    ${instances.join("\n    ")}\n`;
         // only on last warning
         if (showHelp && ++i === duplicateCount) {
-          error += `\n${chalk.white.bold(
-            "Check how you can resolve duplicate packages: "
-          )}\nhttps://github.com/darrenscerri/duplicate-package-checker-webpack-plugin#resolving-duplicate-packages-in-your-bundle\n`;
+          if (helpMessage) {
+            error += `\n${helpMessage}\n`;
+          } else {
+            error += `\n${chalk.white.bold(
+              "Check how you can resolve duplicate packages: "
+            )}\nhttps://github.com/darrenscerri/duplicate-package-checker-webpack-plugin#resolving-duplicate-packages-in-your-bundle\n`;
+          }
         }
         array.push(new Error(error));
       });

--- a/test/simple/__snapshots__/index.test.js.snap
+++ b/test/simple/__snapshots__/index.test.js.snap
@@ -11,6 +11,24 @@ https://github.com/darrenscerri/duplicate-package-checker-webpack-plugin#resolvi
 "
 `;
 
+exports[`Simple dependency tree should output custom help message 1`] = `
+"a
+[0m  Multiple versions of [0m[32m[1ma[22m[39m[37m found:[39m
+[37m[39m    [32m[1m1.0.0[22m[39m [37m[1m./~/a[22m[39m
+    [32m[1m2.0.0[22m[39m [37m[1m./~/b/~/a[22m[39m
+"
+`;
+
+exports[`Simple dependency tree should output custom help message 2`] = `
+"b
+[0m  Multiple versions of [0m[32m[1mb[22m[39m[37m found:[39m
+[37m[39m    [32m[1m1.0.0[22m[39m [37m[1m./~/b[22m[39m
+    [32m[1m2.0.0[22m[39m [37m[1m./~/c/~/d/~/b[22m[39m
+
+Check http://foo.bar.com/baz for more details
+"
+`;
+
 exports[`Simple dependency tree should output errors 1`] = `
 "a
 [0m  Multiple versions of [0m[32m[1ma[22m[39m[37m found:[39m

--- a/test/simple/index.test.js
+++ b/test/simple/index.test.js
@@ -31,6 +31,20 @@ describe("Simple dependency tree", function() {
     });
   });
 
+  it("should output custom help message", function(done) {
+    webpack(
+      MakeConfig({
+        emitError: true,
+        helpMessage: "Check http://foo.bar.com/baz for more details"
+      }),
+      function(err, stats) {
+        expect(stats.compilation.errors[0].message).toMatchSnapshot();
+        expect(stats.compilation.errors[1].message).toMatchSnapshot();
+        done();
+      }
+    );
+  });
+
   it("should output errors in production mode", function(done) {
     webpack(MakeConfig({ emitError: true }, "production"), function(
       err,


### PR DESCRIPTION
I wanted to add support for printing a custom help message when the plugin finds duplicates.

In my project, we are using the plugin only for specific sets of the packages and we have a help page that describes what a developer needs to do to fix the problem with duplicated pages.